### PR TITLE
simple fix for php v8.2.8 error

### DIFF
--- a/src/phpSpreadsheet/Helper.php
+++ b/src/phpSpreadsheet/Helper.php
@@ -789,7 +789,7 @@ class Helper
         $n = $n - 1;
         $r = '';
         for ($i = 1; $n >= 0 && $i < 10; $i++) {
-            $r = chr(0x41 + ($n % pow(26, $i) / pow(26, $i - 1))) . $r;
+            $r = chr(0x41 + intval($n % pow(26, $i) / pow(26, $i - 1))) . $r;
             $n -= pow(26, $i);
         }
         return $r;


### PR DESCRIPTION
fix for php v8.2.8 error with 

Deprecated: Implicit conversion from float [nunber] to int loses precision

```
function num2alpha($n)
{
    $n = $n - 1;
    $r = '';
    for ($i = 1; $n >= 0 && $i < 10; $i++) {
        $r = chr(0x41 + intval($n % pow(26, $i) / pow(26, $i - 1))) . $r;
        $n -= pow(26, $i);
    }
    return $r;
}

var_dump(num2alpha(37));
```